### PR TITLE
feat: initial import from poc

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -1,0 +1,72 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: next build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+env:
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+jobs:
+
+  publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Run Build
+        run: |
+          pnpm build
+
+      - name: Set-up npmjs auth token
+        run: printf "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}\n" >> ~/.npmrc
+
+      - name: Download macadam binaries
+        run: |
+          MACADAM_VERSION=v0.0.2
+          mkdir binaries
+          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-windows-amd64.exe -o binaries/macadam-windows-amd64.exe
+          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-darwin-amd64 -o binaries/macadam-darwin-amd64
+          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-darwin-arm64 -o binaries/macadam-darwin-arm64
+
+      - name: Publish to npmjs
+        run: |
+          PACKAGE_VERSION=$(jq -r '.version' package.json)
+          STRIPPED_VERSION=${PACKAGE_VERSION%-next}
+          SHORT_SHA1=$(git rev-parse --short HEAD)
+          TAG_PATTERN=${STRIPPED_VERSION}-$(date +'%Y%m%d%H%M')-${SHORT_SHA1}
+          echo "Using version ${TAG_PATTERN}"
+          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${TAG_PATTERN}\",#g" package.json
+          pnpm publish --tag next --no-git-checks --access public

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.DS_Store
+dist
+.eslintcache
+**/coverage
+.idea
+output
+.npmrc

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "macadam.js",
+  "version": "0.0.1",
+  "description": "An NPM library to work with macadam from Node projects",
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "npx tsc --build",
+    "clean": "npx tsc --build --clean"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "typescript": "^5.8.3"
+  },
+  "files": [
+    "dist",
+    "binaries",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,39 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.14.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+
+packages:
+
+  '@types/node@22.14.0':
+    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@types/node@22.14.0':
+    dependencies:
+      undici-types: 6.21.0
+
+  typescript@5.8.3: {}
+
+  undici-types@6.21.0: {}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,19 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export const PACKAGE_NAME = 'macadam.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import { PACKAGE_NAME } from './consts';
+
+export async function getMacadamPath(): Promise<string> {
+  let bin = '';
+  if (os.platform() === 'win32') {
+    bin = 'macadam-windows-amd64.exe';
+  } else if (os.platform() === 'darwin') {
+    if (os.arch() === 'arm64') {
+      bin = 'macadam-darwin-arm64';
+    } else if (os.arch() == 'x64') {
+      bin = 'macadam-darwin-amd64';
+    }
+  }
+  if (!bin) {
+    throw new Error(`binary not found for platform ${os.platform()} and architecture ${os.arch()}`);
+  }
+  const packagePath = path.dirname(require.resolve(`${PACKAGE_NAME}/package.json`));
+
+  const filepath = path.resolve(packagePath, 'binaries', bin);
+  await fs.promises.chmod(filepath, '755');
+  return filepath;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": [
+      "node",
+    ],
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/*.ts"
+  ]
+}


### PR DESCRIPTION
- Initial import from PoC
- Use github NPM registry

## Summary by Sourcery

Import initial proof-of-concept for a Node.js library to work with macadam binaries across different platforms

New Features:
- Create a Node.js library for retrieving macadam binaries for different operating systems and architectures

Build:
- Set up TypeScript build configuration
- Configure pnpm as the package manager

CI:
- Add GitHub Actions workflow for building and publishing the package to GitHub NPM registry