### PR TITLE
ci: fix package name to publish on github npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
-  "name": "macadam.js",
+  "name": "@crc-org/macadam.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/crc-org/macadam.js.git"
+  },
   "version": "0.0.1",
   "description": "An NPM library to work with macadam from Node projects",
   "main": "./dist/index.js",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -16,4 +16,4 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export const PACKAGE_NAME = 'macadam.js';
+export const PACKAGE_NAME = '@crc-org/macadam.js';


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update package configuration to use scoped package name '@crc-org/macadam.js' for GitHub npm publication