### PR TITLE
doc: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # macadam.js
 An NPM library to work with macadam from Node projects
+
+## Installation
+
+The library is published on GitHub NPM registry. 
+
+You need to indicate in `.npmrc` where is located the package, and you need to authenticate with a GitHub token (classic) having `read:packages` scope:
+
+.npmrc
+```
+@crc-org:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=<TOKEN>
+```
+
+Then you can install the package for your project:
+
+```
+npm i @crc-org/macadam.js@latest
+```
+
+## Usage
+
+```typescript
+import * as macadamjs from '@crc-org/macadam.js';
+
+const macadam = new macadamjs.Macadam('my-ext');
+await macadam.init();
+await macadam.createVm({
+  imagePath: '/path/to/image.raw',
+  username: 'core',
+});
+const vms = await macadam.listVms({});
+console.log('==> vms', vms);
+
+const startResult = await macadam.startVm({});
+console.log('==> start', startResult);
+
+const stopResult = await macadam.stopVm({});
+console.log('==> stop', stopResult);
+
+const rmResult = await macadam.removeVm({});
+console.log('==> rm result', rmResult);
+
+const vms0 = await macadam.listVms({});
+console.log('==> vms after rm', vms0);
+```


### PR DESCRIPTION
Document how to install NPM from GH registry, and some code sample.

fixes #6

## Summary by Sourcery

Update README with installation instructions for the macadam.js library from GitHub NPM registry and add usage example

New Features:
- Add code sample showing how to use macadam.js library with various VM operations

Documentation:
- Add comprehensive installation guide for the library, including .npmrc configuration and authentication steps
- Provide a detailed usage example demonstrating key library functions