### PR TITLE
fix: use macacam 0.1.0

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -54,11 +54,10 @@ jobs:
 
       - name: Download macadam binaries
         run: |
-          MACADAM_VERSION=v0.0.2
+          MACADAM_VERSION=v0.1.0
           mkdir binaries
           curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-windows-amd64.exe -o binaries/macadam-windows-amd64.exe
-          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-darwin-amd64 -o binaries/macadam-darwin-amd64
-          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-darwin-arm64 -o binaries/macadam-darwin-arm64
+          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-installer-macos-universal.pkg -o binaries/macadam-darwin-amd64          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-darwin-arm64 -o binaries/macadam-installer-macos-universal.pkg
 
       - name: Set version
         run: |

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -57,7 +57,7 @@ jobs:
           MACADAM_VERSION=v0.1.0
           mkdir binaries
           curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-windows-amd64.exe -o binaries/macadam-windows-amd64.exe
-          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-installer-macos-universal.pkg -o binaries/macadam-darwin-amd64          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-darwin-arm64 -o binaries/macadam-installer-macos-universal.pkg
+          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-installer-macos-universal.pkg -o binaries/macadam-installer-macos-universal.pkg
 
       - name: Set version
         run: |

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -17,3 +17,4 @@
  ***********************************************************************/
 
 export const PACKAGE_NAME = '@crc-org/macadam.js';
+export const MACADAM_MACOS_PATH = '/opt/macadam/bin';

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export class Macadam {
     if (extensionApi.env.isWindows) {
       bin = 'macadam-windows-amd64.exe';
     } else if (extensionApi.env.isMac) {
-      bin = 'macadam-installer-universal.pkg';
+      bin = 'macadam-installer-macos-universal.pkg';
     }
     if (!bin) {
       throw new Error(`binary not found for platform ${platform()} and architecture ${arch()}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { chmod } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { arch, platform } from 'node:os';
 import { dirname, resolve } from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 
-import { PACKAGE_NAME } from './consts';
+import { MACADAM_MACOS_PATH, PACKAGE_NAME } from './consts';
 
 type Resolver = (request: string, options?: NodeJS.RequireResolveOptions) => string;
 
@@ -81,9 +81,11 @@ export class Macadam {
 
   protected async _init(resolver?: Resolver): Promise<void> {
     resolver ??= require.resolve;
-    this.#macadamPath = await this.findMacadamPath(resolver);
+    this.#macadamPath = extensionApi.env.isMac
+      ? await this.findInstallMacadam(resolver)
+      : await this.findMacadamPath(resolver);
     if (extensionApi.env.isMac) {
-      this.#utilitiesPath = await this.findUtilitiesPath();
+      this.#utilitiesPath = MACADAM_MACOS_PATH;
     }
     this.#initialized = true;
   }
@@ -93,48 +95,22 @@ export class Macadam {
     if (extensionApi.env.isWindows) {
       bin = 'macadam-windows-amd64.exe';
     } else if (extensionApi.env.isMac) {
-      if (arch() === 'arm64') {
-        bin = 'macadam-darwin-arm64';
-      } else if (arch() === 'x64') {
-        bin = 'macadam-darwin-amd64';
-      }
+      bin = 'macadam-installer-universal.pkg';
     }
     if (!bin) {
       throw new Error(`binary not found for platform ${platform()} and architecture ${arch()}`);
     }
     const packagePath = dirname(resolver(`${PACKAGE_NAME}/package.json`));
-
-    const filepath = resolve(packagePath, 'binaries', bin);
-    await chmod(filepath, '755');
-    return filepath;
+    return resolve(packagePath, 'binaries', bin);
   }
 
-  async findUtilitiesPath(): Promise<string> {
-    const utilities = ['vfkit', 'gvproxy'];
-    let result: string = '';
-    for (const utility of utilities) {
-      const utilityPath = await this.findExecutableInPath(utility);
-      const utilityDir = dirname(utilityPath);
-      if (result && utilityDir !== result) {
-        throw new Error(`utilities must be in the same directory: ${utilities.join(', ')}`);
-      }
-      result = utilityDir;
+  async findInstallMacadam(resolver: Resolver): Promise<string> {
+    const macadamPath = resolve(MACADAM_MACOS_PATH, 'macadam');
+    if (!existsSync(macadamPath)) {
+      const installer = await this.findMacadamPath(resolver);
+      await extensionApi.process.exec('installer', ['-pkg', installer, '-target', '/'], { isAdmin: true });
     }
-    return result;
-  }
-
-  async findExecutableInPath(executable: string): Promise<string> {
-    if (extensionApi.env.isMac) {
-      // grab full path for Linux and mac
-      const { stdout: fullPath } = await extensionApi.process.exec('which', [executable]);
-      return fullPath;
-    } else if (extensionApi.env.isWindows) {
-      // grab full path for Windows
-      const { stdout: fullPath } = await extensionApi.process.exec('where.exe', [executable]);
-      // remove all line break/carriage return characters from full path
-      return fullPath.replace(/(\r\n|\n|\r)/gm, '');
-    }
-    throw new Error('Platform not supported: only Mac and Windows platforms are supported');
+    return macadamPath;
   }
 
   protected getMacadamPath(): string {


### PR DESCRIPTION
Fixes #4

## Summary by Sourcery

Update Macadam handling for macOS to use version 0.1.0, simplifying installation and path management

New Features:
- Add support for Macadam 0.1.0 universal installer on macOS

Bug Fixes:
- Improve Macadam binary installation process on macOS by using a universal installer package

Enhancements:
- Simplify macOS binary path resolution
- Streamline Macadam initialization for macOS