### PR TITLE
fix: publish npm package as public

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -70,6 +70,6 @@ jobs:
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${TAG_PATTERN}\",#g" package.json
       
       - name: publish npm
-        run: npm publish
+        run: npm publish --public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #12

## Summary by Sourcery

Modify npm publish workflow to explicitly publish the package as public

Bug Fixes:
- Resolve issue with npm package visibility by adding --public flag to npm publish command

CI:
- Update GitHub Actions workflow to explicitly publish npm package as public