### PR TITLE
chore: build as commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "An NPM library to work with macadam from Node projects",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "npx tsc --build",
+    "build": "npx tsc --module commonjs",
     "clean": "npx tsc --build --clean",
     "test:unit": "cd src && vitest run --coverage --passWithNoTests",
     "format:check": "prettier --check \"src/**/*.ts\"",


### PR DESCRIPTION
fixes #18

## Summary by Sourcery

Build:
- Modify the `build` script in `package.json` to use the `commonjs` module flag for `tsc`.