### PR TITLE
chore: specify pnpm version in workflow

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -36,6 +36,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
+          version: 10
           run_install: false
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the `next-build` workflow to use pnpm version 10.