### PR TITLE
chore: set pnpm version in package.json

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -36,7 +36,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 10
           run_install: false
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -33,7 +33,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 10
           run_install: false
 
       - uses: actions/setup-node@v4
@@ -59,7 +58,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 10
           run_install: false
 
       - uses: actions/setup-node@v4
@@ -86,7 +84,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 10
           run_install: false
 
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -48,5 +48,6 @@
   ],
   "dependencies": {
     "@podman-desktop/api": "^1.18.0"
-  }
+  },
+  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b"
 }


### PR DESCRIPTION
## Summary by Sourcery

Set the pnpm version in `package.json` to ensure consistent dependency management.

CI:
- Remove explicit pnpm version specification from GitHub Actions workflows to infer it from `package.json`.

Chores:
- Define the pnpm version using the `packageManager` field in `package.json`.