### PR TITLE
feat: support named machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,26 @@ import * as macadamjs from '@crc-org/macadam.js';
 const macadam = new macadamjs.Macadam('my-ext');
 await macadam.init();
 await macadam.createVm({
+  name: 'my-vm',
   imagePath: '/path/to/image.raw',
   username: 'core',
 });
 const vms = await macadam.listVms({});
 console.log('==> vms', vms);
 
-const startResult = await macadam.startVm({});
+const startResult = await macadam.startVm({
+    name: 'my-vm',
+});
 console.log('==> start', startResult);
 
-const stopResult = await macadam.stopVm({});
+const stopResult = await macadam.stopVm({
+    name: 'my-vm',
+});
 console.log('==> stop', stopResult);
 
-const rmResult = await macadam.removeVm({});
+const rmResult = await macadam.removeVm({
+    name: 'my-vm',
+});
 console.log('==> rm result', rmResult);
 
 const vms0 = await macadam.listVms({});

--- a/README.md
+++ b/README.md
@@ -52,3 +52,9 @@ console.log('==> rm result', rmResult);
 const vms0 = await macadam.listVms({});
 console.log('==> vms after rm', vms0);
 ```
+
+## Details
+
+The `type` passed to the constructor is used to differentiate images between callers. When a caller uses the `my-ext` type,
+the images it creates with `startVm({ name: 'vm1' })` will have a real name `my-ext-vm1`. This real name is only visible when executing `macadam list`, 
+but will be transparent when calling `listVms({})`: this call will display the name `vm1`, and will display only the machines whose real name is prefixed by `my-ext`.


### PR DESCRIPTION
Add `name` option to methods.

Name is mandatory, as the default name `macadam` won't be recognized as owned by any library's user.

Can be tested with package `0.0.1-pr23` (https://github.com/crc-org/macadam.js/pkgs/npm/macadam.js/404806794)

## Summary by Sourcery

Add support for named virtual machines. All operations that manage VMs now require a mandatory `name` parameter. Internal prefixing is used to differentiate VMs managed by different library instances.

New Features:
- Introduce a mandatory `name` parameter for creating, starting, stopping, and removing virtual machines.
- Add a `Name` field to the `VmDetails` returned by `listVms`.
- Filter the list of VMs returned by `listVms` to only include machines created by the current instance, displaying user-provided names without the internal prefix.
- Use an internal prefix derived from the constructor `type` argument to manage VM names uniquely per instance.

Documentation:
- Update README example to demonstrate usage with the new `name` parameter.

Tests:
- Update tests to include the mandatory `name` parameter.
- Add tests to verify the VM name prefixing and filtering logic.