### PR TITLE
ci: publish package for PRs

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -27,8 +27,7 @@ env:
 jobs:
   publish:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/publish-from-pr') }}
-    permissions:
-      packages: write  # to publish package on NPM registry
+    permissions: write-all
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -17,14 +17,16 @@
 
 name: PR build
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [labeled]
 
 env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
 jobs:
-
   publish:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/publish-from-pr') }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: PR build
+
+on: [pull_request]
+
+env:
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+jobs:
+
+  publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://npm.pkg.github.com'
+          scope: ${{ github.repository_owner }}
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Run Build
+        run: |
+          pnpm build
+
+      - name: Download macadam binaries
+        run: |
+          MACADAM_VERSION=v0.1.0
+          mkdir binaries
+          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-windows-amd64.exe -o binaries/macadam-windows-amd64.exe
+          curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-installer-macos-universal.pkg -o binaries/macadam-installer-macos-universal.pkg
+
+      - name: Set version
+        run: |
+          PACKAGE_VERSION=$(jq -r '.version' package.json)
+          STRIPPED_VERSION=${PACKAGE_VERSION%-next}
+          SHORT_SHA1=$(git rev-parse --short HEAD)
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          TAG_PATTERN=${STRIPPED_VERSION}-pr${PR_NUMBER}-$(date +'%Y%m%d%H%M')-${SHORT_SHA1}
+          echo "Using version ${TAG_PATTERN}"
+          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${TAG_PATTERN}\",#g" package.json
+      
+      - name: publish npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -19,7 +19,7 @@ name: PR build
 
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, synchronize, opened, reopened]
 
 env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -27,6 +27,8 @@ env:
 jobs:
   publish:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/publish-from-pr') }}
+    permissions:
+      packages: write  # to publish package on NPM registry
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary by Sourcery

Add a CI workflow to build and publish development packages for pull requests.

CI:
- Introduce a new GitHub Actions workflow (`pr-build.yaml`) that runs on pull requests.
- Build the package using pnpm and Node.js 22.
- Download `macadam` binaries during the build process.
- Dynamically version the package for each PR build using the PR number and commit SHA.
- Publish the versioned package to the GitHub Package Registry.