### PR TITLE
chore: switch to --machine-name not --name for init.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export interface CreateVmOptions extends CommonOptions {
   // positional args
   imagePath: string;
   // flags
-  name: string; // --name
+  name: string; // --machine-name
   sshIdentityPath?: string; // --ssh-identity-path
   username?: string; // -- username
 }
@@ -147,7 +147,7 @@ export class Macadam {
     if (!this.#initialized) {
       throw new Error('component not initialized. You must call init() before');
     }
-    const parameters: string[] = ['init', options.imagePath, '--name', this.realMachineName(options.name)];
+    const parameters: string[] = ['init', options.imagePath, '--machine-name', this.realMachineName(options.name)];
     if (options.sshIdentityPath) {
       parameters.push('--ssh-identity-path');
       parameters.push(options.sshIdentityPath);

--- a/src/macadam.spec.ts
+++ b/src/macadam.spec.ts
@@ -218,7 +218,7 @@ describe('init is done', () => {
     });
     expect(extensionApi.process.exec).toHaveBeenCalledWith(
       expect.anything(),
-      ['init', '/path/to/image.raw', '--name', 'mytype-vm1'],
+      ['init', '/path/to/image.raw', '--machine-name', 'mytype-vm1'],
       {
         env: {
           CONTAINERS_HELPER_BINARY_DIR: MACADAM_MACOS_PATH,
@@ -239,7 +239,7 @@ describe('init is done', () => {
       [
         'init',
         '/path/to/image.raw',
-        '--name',
+        '--machine-name',
         'mytype-vm1',
         '--ssh-identity-path',
         '/path/to/id',


### PR DESCRIPTION
chore: switch to --machine-name not --name for init.

Closes https://github.com/crc-org/macadam.js/issues/28

--name was used, when it should be --machine-name.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>

## Summary by Sourcery

Chores:
- Replace --name flag with --machine-name in initialization process