### PR TITLE
feat: use macadam v0.1.1

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Download macadam binaries
         run: |
-          MACADAM_VERSION=v0.1.0
+          MACADAM_VERSION=v0.1.1
           mkdir binaries
           curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-windows-amd64.exe -o binaries/macadam-windows-amd64.exe
           curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-installer-macos-universal.pkg -o binaries/macadam-installer-macos-universal.pkg


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Upgrade to macadam v0.1.1 in the build workflow