### PR TITLE
feat: support Linux platform with manual install

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,10 @@ export class Macadam {
       bin = 'macadam-windows-amd64.exe';
     } else if (extensionApi.env.isMac) {
       bin = 'macadam-installer-macos-universal.pkg';
+    } else if (extensionApi.env.isLinux) {
+      // hardcoded for the moment, the binary must be installed manually on this directory
+      // and gvproxy must be installed as /usr/local/libexec/podman/gvproxy
+      return '/opt/macadam/bin/macadam';
     }
     if (!bin) {
       throw new Error(`binary not found for platform ${platform()} and architecture ${arch()}`);


### PR DESCRIPTION
On Linux, binaries must be installed by the user:
- macadam in /opt/macadam/bin/ (from https://github.com/crc-org/macadam/releases/tag/v0.1.1, or newer)
- gvproxy in /usr/local/libexec/podman/ (from https://github.com/containers/gvisor-tap-vsock/releases/tag/v0.8.5 or newer)

## Summary by Sourcery

Add support for Linux platform by specifying manual binary installation paths for macadam and gvproxy

New Features:
- Add Linux platform support with manual binary installation requirements

Chores:
- Hardcode Linux binary path for macadam in /opt/macadam/bin/