### PR TITLE
chore: publish the package using next tag

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -66,5 +66,5 @@ jobs:
       - name: Set-up npmjs auth token
         run: printf "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}\n" >> ~/.npmrc
 
-      - name: publish npm
-        run: npm publish
+      - name: publish npm package
+        run: pnpm publish  --tag next --no-git-checks --access public


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Modified the GitHub Actions workflow to use pnpm for publishing the package with the 'next' tag