### PR TITLE
chore: add provenance when publishing the package to npm registry

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -17,6 +17,9 @@
 
 name: next build
 
+permissions:
+  id-token: write
+
 on:
   workflow_dispatch:
   push:
@@ -67,4 +70,4 @@ jobs:
         run: printf "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}\n" >> ~/.npmrc
 
       - name: publish npm package
-        run: pnpm publish  --tag next --no-git-checks --access public
+        run: pnpm publish --provenance --tag next --no-git-checks --access public

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "version": "0.0.1",
   "description": "An NPM library to work with macadam from Node projects",
   "main": "./dist/index.js",
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "scripts": {
     "build": "npx tsc --module commonjs",
     "clean": "npx tsc --build --clean",


### PR DESCRIPTION
## Summary by Sourcery

Add provenance configuration for npm package publishing

CI:
- Updated GitHub workflow to enable OIDC token for provenance
- Modified npm publish command to include provenance flag

Deployment:
- Configured package.json to enable provenance and public access for npm publishing