### PR TITLE
feat: executeCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ const startResult = await macadam.startVm({
 });
 console.log('==> start', startResult);
 
+const executeResult = await macadam.executeCommand({
+    name: 'my-vm',
+    command: 'ls',
+    args: [ 'ls' ],
+});
+console.log('==> execute', executeResult);
+
 const stopResult = await macadam.stopVm({
     name: 'my-vm',
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,13 @@ export interface StopVmOptions extends CommonOptions {
   name: string;
 }
 
+export interface ExecuteCommandOptions extends CommonOptions {
+  // positional args
+  name: string;
+  command: string;
+  args: string[];
+}
+
 export interface VmDetails {
   Name: string;
   Image: string;
@@ -229,6 +236,17 @@ export class Macadam {
     return await extensionApi.process.exec(
       this.#macadamPath,
       ['stop', this.realMachineName(options.name)],
+      this.getFinalOptions(options.runOptions, options.containerProvider),
+    );
+  }
+
+  async executeCommand(options: ExecuteCommandOptions): Promise<extensionApi.RunResult> {
+    if (!this.#initialized) {
+      throw new Error('component not initialized. You must call init() before');
+    }
+    return await extensionApi.process.exec(
+      this.#macadamPath,
+      ['ssh', this.realMachineName(options.name), options.command, ...options.args],
       this.getFinalOptions(options.runOptions, options.containerProvider),
     );
   }

--- a/src/macadam.spec.ts
+++ b/src/macadam.spec.ts
@@ -336,4 +336,17 @@ describe('init is done', () => {
       },
     });
   });
+
+  test('executeCommand', async () => {
+    await macadam.executeCommand({
+      name: 'vm1',
+      command: 'ls',
+      args: ['/'],
+    });
+    expect(extensionApi.process.exec).toHaveBeenCalledWith(expect.anything(), ['ssh', 'mytype-vm1', 'ls', '/'], {
+      env: {
+        CONTAINERS_HELPER_BINARY_DIR: MACADAM_MACOS_PATH,
+      },
+    });
+  });
 });


### PR DESCRIPTION
adds an `executeCommand` method, to be able to execute a shell command in the VM through ssh

needed for https://github.com/redhat-developer/podman-desktop-rhel-ext/issues/132