### PR TITLE
feat: use macadam v0.2.0

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Download macadam binaries
         run: |
-          MACADAM_VERSION=v0.1.1
+          MACADAM_VERSION=v0.2.0
           mkdir binaries
           curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-windows-amd64.exe -o binaries/macadam-windows-amd64.exe
           curl -L https://github.com/crc-org/macadam/releases/download/${MACADAM_VERSION}/macadam-installer-macos-universal.pkg -o binaries/macadam-installer-macos-universal.pkg

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/crc-org/macadam.js.git"
   },
-  "version": "0.0.1",
+  "version": "0.2.0",
   "description": "An NPM library to work with macadam from Node projects",
   "main": "./dist/index.js",
   "publishConfig": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped application version to 0.2.0.
  - Updated build pipeline to use Macadam v0.2.0 binaries for Windows and macOS.

- Notes
  - No user-facing functionality changes in this release.
  - App behavior and features remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->