### PR TITLE
chore: install to /usr/local/bin instead of /opt for linux

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export class Macadam {
     } else if (extensionApi.env.isLinux) {
       // hardcoded for the moment, the binary must be installed manually on this directory
       // and gvproxy must be installed as /usr/local/libexec/podman/gvproxy
-      return '/opt/macadam/bin/macadam';
+      return '/usr/local/bin/macadam';
     }
     if (!bin) {
       throw new Error(`binary not found for platform ${platform()} and architecture ${arch()}`);

--- a/src/macadam.spec.ts
+++ b/src/macadam.spec.ts
@@ -101,6 +101,25 @@ test(
   },
 );
 
+test(
+  'init on Linux',
+  {
+    skip: platform() !== 'linux',
+  },
+  async () => {
+    vi.mocked(extensionApi.env).isMac = false;
+    vi.mocked(extensionApi.env).isWindows = false;
+    vi.mocked(extensionApi.env).isLinux = true;
+    const resolver = vi.fn<(request: string, options?: NodeJS.RequireResolveOptions) => string>();
+    resolver.mockReturnValue(resolve('/', 'path', 'to', 'extension', 'package.json'));
+    await macadam._init(resolver);
+
+    expect(macadam.getMacadamPath()).toEqual('/usr/local/bin/macadam');
+
+    expect(macadam.getUtilitiesPath()).toBeUndefined();
+  },
+);
+
 describe('getFinalOptions', () => {
   test('with no option and no utilitiesPath', () => {
     const result = macadam.getFinalOptions();


### PR DESCRIPTION
chore: install to /usr/local/bin instead of /opt for linux

See: https://github.com/crc-org/macadam.js/issues/47

Instead of installing to /opt, we should be installing to
/usr/local/bin/macadam which is more standarized across Linux
distributions (will work for OS' with read-only root structures such as
Fedora Silverblue, CoreOS, etc.).

Closes https://github.com/crc-org/macadam.js/issues/47

Signed-off-by: Charlie Drage <charlie@charliedrage.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - On Linux, the app now correctly defaults to /usr/local/bin/macadam when no custom path is configured, improving startup reliability and reducing configuration issues.

- Tests
  - Added Linux-specific test coverage to validate binary path resolution and ensure expected behavior when no utilities path is provided, increasing confidence in Linux initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->