### PR TITLE
chore: use node 24

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Execute pnpm
@@ -62,7 +62,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Execute pnpm
@@ -88,7 +88,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Execute pnpm

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@eslint/compat": "^2.0.0",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.24.0",
-    "@types/node": "^22.14.0",
+    "@types/node": "^24",
     "@vitest/coverage-v8": "^4.0.16",
     "@vitest/eslint-plugin": "^1.1.43",
     "eslint": "^9.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,14 +22,14 @@ importers:
         specifier: ^9.24.0
         version: 9.39.2
       '@types/node':
-        specifier: ^22.14.0
-        version: 22.14.0
+        specifier: ^24
+        version: 24.10.4
       '@vitest/coverage-v8':
         specifier: ^4.0.16
-        version: 4.0.16(vitest@4.0.16(@types/node@22.14.0))
+        version: 4.0.16(vitest@4.0.16(@types/node@24.10.4))
       '@vitest/eslint-plugin':
         specifier: ^1.1.43
-        version: 1.6.6(eslint@9.39.2)(typescript@5.8.3)(vitest@4.0.16(@types/node@22.14.0))
+        version: 1.6.6(eslint@9.39.2)(typescript@5.8.3)(vitest@4.0.16(@types/node@24.10.4))
       eslint:
         specifier: ^9.24.0
         version: 9.39.2
@@ -74,7 +74,7 @@ importers:
         version: 8.52.0(eslint@9.39.2)(typescript@5.8.3)
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@22.14.0)
+        version: 4.0.16(@types/node@24.10.4)
 
 packages:
 
@@ -517,8 +517,8 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@22.14.0':
-    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
+  '@types/node@24.10.4':
+    resolution: {integrity: sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==}
 
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
@@ -2013,8 +2013,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -2464,9 +2464,9 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@22.14.0':
+  '@types/node@24.10.4':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.16.0
 
   '@types/semver@7.7.0': {}
 
@@ -2716,7 +2716,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@22.14.0))':
+  '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@24.10.4))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.16
@@ -2729,18 +2729,18 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@types/node@22.14.0)
+      vitest: 4.0.16(@types/node@24.10.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.6.6(eslint@9.39.2)(typescript@5.8.3)(vitest@4.0.16(@types/node@22.14.0))':
+  '@vitest/eslint-plugin@1.6.6(eslint@9.39.2)(typescript@5.8.3)(vitest@4.0.16(@types/node@24.10.4))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.52.0
       '@typescript-eslint/utils': 8.52.0(eslint@9.39.2)(typescript@5.8.3)
       eslint: 9.39.2
     optionalDependencies:
       typescript: 5.8.3
-      vitest: 4.0.16(@types/node@22.14.0)
+      vitest: 4.0.16(@types/node@24.10.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -2753,13 +2753,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.16(vite@7.3.1(@types/node@22.14.0))':
+  '@vitest/mocker@4.0.16(vite@7.3.1(@types/node@24.10.4))':
     dependencies:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.14.0)
+      vite: 7.3.1(@types/node@24.10.4)
 
   '@vitest/pretty-format@4.0.16':
     dependencies:
@@ -4203,7 +4203,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@6.21.0: {}
+  undici-types@7.16.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -4239,7 +4239,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@7.3.1(@types/node@22.14.0):
+  vite@7.3.1(@types/node@24.10.4):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4248,13 +4248,13 @@ snapshots:
       rollup: 4.55.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 24.10.4
       fsevents: 2.3.3
 
-  vitest@4.0.16(@types/node@22.14.0):
+  vitest@4.0.16(@types/node@24.10.4):
     dependencies:
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(vite@7.3.1(@types/node@22.14.0))
+      '@vitest/mocker': 4.0.16(vite@7.3.1(@types/node@24.10.4))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
@@ -4271,10 +4271,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@22.14.0)
+      vite: 7.3.1(@types/node@24.10.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 24.10.4
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
fixes #72 

depends on #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated Node.js runtime version from 22 to 24 in GitHub Actions CI/CD workflows across lint-format, typecheck, and unit-tests jobs
* Updated @types/node development dependency to version 24 for Node.js type definitions alignment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->