### PR TITLE
fix: macOS installer renamed

### DIFF
--- a/.github/workflows/npmjs-publish.yaml
+++ b/.github/workflows/npmjs-publish.yaml
@@ -106,7 +106,7 @@ jobs:
           MACADAM_VERSION=$(grep 'MACADAM_VERSION\s*=' src/consts.ts | sed "s/.*'\([^']*\)';/\1/")
           mkdir binaries
           curl -L https://github.com/crc-org/macadam/releases/download/v${MACADAM_VERSION}/macadam-windows-amd64.exe -o binaries/macadam-windows-amd64.exe
-          curl -L https://github.com/crc-org/macadam/releases/download/v${MACADAM_VERSION}/macadam-installer-macos-universal.pkg -o binaries/macadam-installer-macos-universal.pkg
+          curl -L https://github.com/crc-org/macadam/releases/download/v${MACADAM_VERSION}/macadam-installer-macos-universal-signed.pkg -o binaries/macadam-installer-macos-universal-signed.pkg
 
       - name: Show publish parameters
         run: |

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,7 @@ export class Macadam {
     if (extensionApi.env.isWindows) {
       bin = 'macadam-windows-amd64.exe';
     } else if (extensionApi.env.isMac) {
-      bin = 'macadam-installer-macos-universal.pkg';
+      bin = 'macadam-installer-macos-universal-signed.pkg';
     } else if (extensionApi.env.isLinux) {
       // binary must be installed manually, gvproxy must be installed as /usr/local/libexec/podman/gvproxy
       return this.findLinuxBinaryPath() ?? MACADAM_LINUX_PATHS[0];

--- a/src/macadam.spec.ts
+++ b/src/macadam.spec.ts
@@ -98,7 +98,7 @@ test(
 
     expect(extensionApi.process.exec).toHaveBeenCalledWith(
       'installer',
-      ['-pkg', '/path/to/extension/binaries/macadam-installer-macos-universal.pkg', '-target', '/'],
+      ['-pkg', '/path/to/extension/binaries/macadam-installer-macos-universal-signed.pkg', '-target', '/'],
       { isAdmin: true },
     );
   },
@@ -217,7 +217,7 @@ test(
 
     expect(extensionApi.process.exec).toHaveBeenCalledWith(
       'installer',
-      ['-pkg', '/path/to/extension/binaries/macadam-installer-macos-universal.pkg', '-target', '/'],
+      ['-pkg', '/path/to/extension/binaries/macadam-installer-macos-universal-signed.pkg', '-target', '/'],
       { isAdmin: true },
     );
   },


### PR DESCRIPTION
fixes #237 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated macOS binary downloads to use the signed universal installer package.
  * Ensured macOS installation paths consistently reference the signed installer.

* **Tests**
  * Updated macOS installation checks to validate the signed package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->